### PR TITLE
テストケースの重複チェック機能を追加

### DIFF
--- a/database/test_repository.py
+++ b/database/test_repository.py
@@ -4,15 +4,44 @@ from .connection import get_connection
 def insert_test_case(
     code_id: int, input_val: str, expected_output: str, description: str
 ):
-    """テストケースをデータベースに挿入します。"""
+    """テストケースをデータベースに挿入します。
+    
+    同じコードに対して同じ入力と期待される出力の組み合わせが既に存在する場合は、
+    重複を避けるために挿入を行いません。
+
+    Args:
+        code_id: テストケースが関連付けられるコードのID
+        input_val: テストケースの入力値
+        expected_output: テストケースの期待される出力
+        description: テストケースの説明
+
+    Returns:
+        True: 挿入が成功した場合、または同じテストケースが既に存在する場合
+        False: エラーが発生した場合
+    """
     conn = get_connection()
     cursor = conn.cursor()
     try:
+        # 既存のテストケースをチェック
+        cursor.execute(
+            """
+            SELECT id FROM test_cases 
+            WHERE code_id = ? AND input = ? AND expected_output = ?
+            """,
+            (code_id, input_val, expected_output),
+        )
+        existing_test = cursor.fetchone()
+        if existing_test:
+            print(f"Test case already exists with ID: {existing_test[0]}")
+            conn.close()
+            return True
+
+        # 新しいテストケースを挿入
         cursor.execute(
             """
             INSERT INTO test_cases (code_id, input, expected_output, description)
             VALUES (?, ?, ?, ?)
-        """,
+            """,
             (code_id, input_val, expected_output, description),
         )
         conn.commit()


### PR DESCRIPTION
# 変更内容

test_repository.pyのinsert_test_case()関数に重複チェック機能を追加しました：

- code_id、input_val、expected_outputの組み合わせが一致するレコードが既に存在する場合は、新しい挿入を行わず、既存のテストケースのIDを表示
- 重複がない場合のみ、新しいテストケースをデータベースに挿入
- 重複の場合もエラーではなくTrueを返すため、既存の処理に影響を与えない

これにより、コードと同様にテストケースも重複を許さない仕様となりました。